### PR TITLE
Small fix in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # Xbox Controller Profiles for Dolphin Emulator
 
-
 This repository contains a series of configured profiles for Xbox controllers for Dolphin Emulator for both Windows and MAC OS.
 
 ## How To Use
 
 1. Download the correct file for your OS (see the .ini filenames).
-2. On Windows, move the downloaded file to DIR:\Users\Your User\Documents\Dolphin Emulator\Config\Profiles. If you are using MacOS the path is /Users/yourusername/Library/Application Support/Dolphin/Config/Profiles/Wiimote.
+2. On Windows, move the downloaded file to "DIR:\Users\Your User\Documents\Dolphin Emulator\Config\Profiles\Wiimote". If you are using MacOS the path is "/Users/yourusername/Library/Application Support/Dolphin/Config/Profiles/Wiimote".
 3. Open Dolphin and click on "Controllers".
-4. Select the Wiimote you want to configure, choose "Emulated Wiimote" and then, configure.
-5. In profiles, choose the profile you want. Then, select load. Click on ok.
+4. Select the Wiimote you want to configure, choose "Emulated Wiimote" and then, "Configure".
+5. In profiles, choose the profile you want. Then, select load. Make sure the right device is selected. Click on "OK".
+6. Repeat steps 4 and 5 for additional controllers.
 
 Done!
 Enjoy playing your favorite games using your Xbox controller.


### PR DESCRIPTION
"\Wiimote" was missing in the Windows path
Additional minor improvements